### PR TITLE
ci: Add release support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   QA:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install prerequisites
         run: sudo apt-get update && sudo apt-get install -y libudev-dev
@@ -32,7 +32,7 @@ jobs:
     needs:
       - QA
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install prerequisites
         run: |
@@ -54,7 +54,7 @@ jobs:
     needs:
       - QA
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install prerequisites
         run: |


### PR DESCRIPTION
To release the software, push a tag as follows:

    tag="v$(sed -nE 's/^version = "([^"]+)"/\1/p' Cargo.toml)"
    git tag $tag
    git push origin $tag